### PR TITLE
Add ability to check and fix Django settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,7 +11,7 @@ indent_style = space
 indent_size = 2
 max_line_length = 80
 
-[*.{ps1,py,sh}]
+[*.{ps1,py,sh,spec}]
 indent_style = space
 indent_size = 4
 max_line_length = 80

--- a/.gitattributes
+++ b/.gitattributes
@@ -16,6 +16,7 @@
 *.rst text eol=lf
 *.sass text eol=lf
 *.scss text eol=lf
+*.spec text eol=lf
 *.sh text eol=lf
 *.toml text eol=lf
 *.txt text eol=lf

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,10 +12,11 @@ python -m venv ./.venv
 (windows) ./.venv/Scripts/Activate.ps1
 ```
 
-Install the package, and developer tools:
+First install the developer tools, then the package in editable mode:
 
 ```console
-$ pip install -r requirements-dev.txt
+$ python -m pip install -r requirements-dev.txt
+$ python -m pip install -e .
 ```
 
 Run the command line tool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,7 +32,9 @@ stages:
           versionSpec: '$(PYTHON_VERSION)'
           architecture: "x64"
 
-      - script: python -m pip install -r requirements-dev.txt
+      - script: |
+          python -m pip install pip --upgrade --upgrade-strategy eager
+          python -m pip install -r requirements-dev.txt
         displayName: "CR-QC: Install local package"
 
       - script: cr --help
@@ -65,7 +67,9 @@ stages:
         versionSpec: "3.10"
         architecture: "x64"
 
-    - script: python -m pip install -r requirements-pipeline.txt
+    - script: |
+        python -m pip install pip --upgrade --upgrade-strategy eager
+        python -m pip install -r requirements-pipeline.txt
       displayName: "CR-QC: Install"
 
     - script: pytest
@@ -89,7 +93,9 @@ stages:
         versionSpec: "3.10"
         architecture: "x64"
 
-    - script: python -m pip install -r requirements-pipeline.txt
+    - script: |
+        python -m pip install pip --upgrade --upgrade-strategy eager
+        python -m pip install -r requirements-pipeline.txt
       displayName: "CR-QC: Install"
 
     - script: pytest
@@ -116,7 +122,9 @@ stages:
         versionSpec: "3.10"
         architecture: "x64"
 
-    - script: python -m pip install -r requirements-pipeline.txt
+    - script: |
+        python -m pip install pip --upgrade --upgrade-strategy eager
+        python -m pip install -r requirements-pipeline.txt
       displayName: "CR-QC: Install"
 
     - script: pytest

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,8 +33,8 @@ stages:
           architecture: "x64"
 
       - script: |
-          python -m pip install pip --upgrade --upgrade-strategy eager
           python -m pip install -r requirements-dev.txt
+          python -m pip install -e .
         displayName: "CR-QC: Install local package"
 
       - script: cr --help
@@ -68,8 +68,8 @@ stages:
         architecture: "x64"
 
     - script: |
-        python -m pip install pip --upgrade --upgrade-strategy eager
         python -m pip install -r requirements-pipeline.txt
+        python -m pip install -e .
       displayName: "CR-QC: Install"
 
     - script: pytest
@@ -94,8 +94,8 @@ stages:
         architecture: "x64"
 
     - script: |
-        python -m pip install pip --upgrade --upgrade-strategy eager
         python -m pip install -r requirements-pipeline.txt
+        python -m pip install -e .
       displayName: "CR-QC: Install"
 
     - script: pytest
@@ -123,8 +123,8 @@ stages:
         architecture: "x64"
 
     - script: |
-        python -m pip install pip --upgrade --upgrade-strategy eager
         python -m pip install -r requirements-pipeline.txt
+        python -m pip install -e .
       displayName: "CR-QC: Install"
 
     - script: pytest

--- a/cr.spec
+++ b/cr.spec
@@ -4,7 +4,9 @@ a = Analysis(
     ["cr/cli.py"],
     pathex=[],
     binaries=[],
-    datas=[],
+    datas=[
+        ("cr/templates", "cr/templates"),
+    ],
     hiddenimports=[],
     hookspath=[],
     hooksconfig={},

--- a/cr/__init__.py
+++ b/cr/__init__.py
@@ -1,3 +1,4 @@
+import enum
 import logging
 
 
@@ -14,9 +15,44 @@ LOGGER = logging.getLogger("cr")
 USER_AGENT = f"CodeRed-CLI/{VERSION} ({DOCS_LINK})"
 
 
+class ConfigurationError(Exception):
+    """
+    Raised when project does not match expected configuration.
+    """
+
+    pass
+
+
 class UserCancelError(Exception):
     """
     Raised when a user intentionally cancels the current operation.
     """
 
     pass
+
+
+class AppType(enum.Enum):
+    CODEREDCMS = "coderedcms"
+    DJANGO = "django"
+    HTML = "html"
+    WAGTAIL = "wagtail"
+    WORDPRESS = "wordpress"
+
+    def __str__(self):
+        return self.value
+
+
+class DatabaseType(enum.Enum):
+    MARIADB = "mariadb"
+    POSTGRES = "postgres"
+
+    def __str__(self):
+        return self.value
+
+
+class Env(enum.Enum):
+    PROD = "prod"
+    STAGING = "staging"
+
+    def __str__(self):
+        return self.value

--- a/cr/rich_utils.py
+++ b/cr/rich_utils.py
@@ -30,7 +30,7 @@ RICH_THEME = Theme(
         "logging.level.warning": "yellow",
         "progress.download": "bright_green",
         "progress.percentage": "bright_magenta",
-        "prompt.choices": "bright_magenta",
+        "prompt.choices": "yellow",
         # Custom.
         "cr.argparse_args": "cyan",
         "cr.argparse_groups": "default",

--- a/cr/templates/settings-mariadb.py.txt
+++ b/cr/templates/settings-mariadb.py.txt
@@ -1,0 +1,13 @@
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.mysql",
+        "HOST": os.environ["DB_HOST"],
+        "NAME": os.environ["DB_NAME"],
+        "USER": os.environ["DB_USER"],
+        "PASSWORD": os.environ["DB_PASSWORD"],
+        "OPTIONS": {
+            "ssl": {},
+            "charset": "utf8mb4",
+        },
+    }
+}

--- a/cr/templates/settings-postgres.py.txt
+++ b/cr/templates/settings-postgres.py.txt
@@ -1,0 +1,10 @@
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.postgresql_psycopg2",
+        "HOST": os.environ["DB_HOST"],
+        "NAME": os.environ["DB_NAME"],
+        "USER": os.environ["DB_USER"],
+        "PASSWORD": os.environ["DB_PASSWORD"],
+        "OPTIONS": {"sslmode": "require"},
+    }
+}

--- a/cr/templates/settings-sqlite.py.txt
+++ b/cr/templates/settings-sqlite.py.txt
@@ -1,0 +1,6 @@
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": os.path.join(BASE_DIR, "db.sqlite3"),
+    }
+}

--- a/cr/templates/settings-top.py.txt
+++ b/cr/templates/settings-top.py.txt
@@ -1,0 +1,5 @@
+from .base import *  # noqa
+import os
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = False

--- a/cr/templates/settings-wagtail.py.txt
+++ b/cr/templates/settings-wagtail.py.txt
@@ -1,0 +1,1 @@
+WAGTAILADMIN_BASE_URL = f"http://{os.environ['VIRTUAL_HOST']}"

--- a/cr/templates/settings.py.txt
+++ b/cr/templates/settings.py.txt
@@ -1,0 +1,15 @@
+# -- Recommended CodeRed Cloud settings ---------------------------------------
+
+ALLOWED_HOSTS = [os.environ["VIRTUAL_HOST"]]
+
+SECRET_KEY = os.environ["RANDOM_SECRET_KEY"]
+
+STATIC_URL = "/static/"
+STATIC_ROOT = BASE_DIR / "static"
+
+MEDIA_URL = "/media/"
+MEDIA_ROOT = BASE_DIR / "media"
+
+# Built-in email sending service provided by CodeRed Cloud.
+# Change this to a different backend or SMTP server to use your own.
+EMAIL_BACKEND = "django_sendmail_backend.backends.EmailBackend"

--- a/cr/utils.py
+++ b/cr/utils.py
@@ -17,6 +17,11 @@ EXCLUDE_DIRNAMES = ["__pycache__", "node_modules", "htmlcov", "venv"]
 List of directory names to always exclude from deployments.
 """
 
+TEMPLATE_PATH = Path(__file__).parent / "templates"
+"""
+Templates directory included with this project.
+"""
+
 
 def get_command(program: str) -> Path:
     r"""
@@ -246,3 +251,11 @@ def paths_to_deploy(
                 lp.append(fpr)
 
     return lp
+
+
+def get_template(t: str) -> str:
+    """
+    Read file ``t`` from the templates directory and return it as a string.
+    """
+    template = TEMPLATE_PATH / t
+    return template.read_text()

--- a/cr/utils.py
+++ b/cr/utils.py
@@ -1,5 +1,5 @@
 """
-Subprocess and filesystem utilities for cross-platform compatibility.
+Subprocess and filesystem utilities for working with the local project.
 
 Copyright (c) 2022 CodeRed LLC.
 """
@@ -8,8 +8,9 @@ from subprocess import PIPE, Popen
 from typing import IO, List, Tuple, Union
 import io
 import os
+import re
 
-from cr import LOGGER
+from cr import LOGGER, ConfigurationError, DatabaseType
 
 
 EXCLUDE_DIRNAMES = ["__pycache__", "node_modules", "htmlcov", "venv"]
@@ -253,9 +254,151 @@ def paths_to_deploy(
     return lp
 
 
-def get_template(t: str) -> str:
+def template(t: str) -> str:
     """
     Read file ``t`` from the templates directory and return it as a string.
     """
-    template = TEMPLATE_PATH / t
-    return template.read_text()
+    return (TEMPLATE_PATH / t).read_text()
+
+
+def django_manage_check(p: Path) -> None:
+    if not (p / "manage.py").is_file():
+        raise FileNotFoundError("manage.py")
+
+
+def django_requirements_check(p: Path) -> None:
+    if not (p / "requirements.txt").is_file():
+        raise FileNotFoundError("requirements.txt")
+
+
+def django_settings_check(p: Path) -> None:
+    """
+    Given a path to a settings file ``p``, check the contents of the settings file.
+    """
+    if not p.is_file():
+        raise FileNotFoundError(p)
+    contents = p.read_text()
+    if "VIRTUAL_HOST" not in contents or "DB_HOST" not in contents:
+        raise ConfigurationError()
+
+
+def django_settings_fix(p: Path, db: DatabaseType) -> None:
+    """
+    Given a path to a settings file ``p``, create and/or rewrite existing
+    settings in the expected format.
+
+    ``p`` Should be a sanctioned settings path, e.g. project/settings/prod.py
+    """
+    project_dir = p.parent.parent
+    settings = project_dir / "settings.py"
+    settings_dir = project_dir / "settings"
+    settings_base = settings_dir / "base.py"
+
+    # If we don't have a settings.py or a settings/base.py, give up.
+    if not (settings.is_file() or settings_base.is_file()):
+        raise FileNotFoundError(
+            "Could not find any Django settings. "
+            f"Does the folder contain a Django project named "
+            f"`{project_dir.name}`?"
+        )
+
+    # Check for settings.py and convert to settings/base.py.
+    if settings.is_file() and not settings_base.is_file():
+        LOGGER.info("Creating %s", settings_base)
+        # Make settings dir.
+        settings_dir.mkdir(parents=True, exist_ok=True)
+        # Move settings.py to settings/base.py
+        settings.rename(settings_base)
+
+    # Ensure paths are correct in settings/base.py
+    settings_str = settings_base.read_text()
+    # Rewrite BASE_DIR to accurately reflect the location.
+    # Django >=3.1 settings have ``BASE_DIR = Path``
+    settings_str = re.sub(
+        r"^BASE_DIR\s+=\s+Path.+$",
+        r"BASE_DIR = Path(__file__).resolve().parent.parent.parent",
+        settings_str,
+        flags=re.MULTILINE,
+    )
+    # Django <3.1 and Wagtail settings have ``BASE_DIR = os.path``
+    settings_str = re.sub(
+        r"^BASE_DIR\s+=\s+os\..+$",
+        r"from pathlib import Path\n"
+        r"BASE_DIR = Path(__file__).resolve().parent.parent.parent",
+        settings_str,
+        flags=re.MULTILINE,
+    )
+    LOGGER.info("Writing to %s", settings_base)
+    settings_base.write_text(settings_str)
+
+    # Create desired settings file.
+    if not p.exists():
+        p.write_text(template("settings-top.py.txt"))
+
+    # If settings file does not look correct, append our recommended.
+    settings_str = p.read_text()
+    if not re.findall(
+        r"os\.environ\[\s*[\'\"]VIRTUAL_HOST[\'\"]\s*\]",
+        settings_str,
+    ):
+        settings_str += "\n"
+        settings_str += template("settings.py.txt")
+    if not re.findall(
+        r"os\.environ\[\s*[\'\"]DB_HOST[\'\"]\s*\]",
+        settings_str,
+    ):
+        settings_str += "\n"
+        settings_str += template(f"settings-{db}.py.txt")
+    LOGGER.info("Writing to %s", p)
+    p.write_text(settings_str)
+
+
+def django_wsgi_check(p: Path, project: str):
+    """
+    Checks for existence of a wsgi.py file in the project folder.
+    """
+    wsgi = p / project / "wsgi.py"
+    if not wsgi.is_file():
+        wsgi_relative = wsgi.relative_to(p)
+        raise FileNotFoundError(wsgi_relative)
+
+
+def django_wsgi_find(p: Path) -> str:
+    """
+    Find a subdirectory of ``p`` that contains a wsgi.py file.
+    """
+    for item in p.iterdir():
+        if item.is_dir() and (item / "wsgi.py").is_file():
+            return item.name
+    raise FileNotFoundError("wsgi.py")
+
+
+def html_index_check(p: Path) -> None:
+    """
+    Checks for existence of an index.html file.
+    """
+    if not (p / "index.html").is_file():
+        raise FileNotFoundError("index.html")
+
+
+def wagtail_settings_fix(p: Path) -> None:
+    """
+    Given a path to a settings file ``p``, append any Wagtail-specific settings
+    if they are missing.
+    """
+    settings_str = p.read_text()
+    if "WAGTAILADMIN_BASE_URL" not in settings_str:
+        settings_str = p.read_text()
+        settings_str += "\n"
+        settings_str += template("settings-wagtail.py.txt")
+        LOGGER.info("Writing to %s", p)
+        p.write_text(settings_str)
+
+
+def wordpress_wpconfig_check(p: Path) -> None:
+    """
+    Checks for existence of a wp-config.php file.
+    TODO: Inspect the file similar to Django settings functionality.
+    """
+    if not (p / "wp-config.php").is_file():
+        raise FileNotFoundError("wp-config.php")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,5 +59,8 @@ ignore_missing_imports = true
 [tool.setuptools]
 packages = ["cr", "cr.templates"]
 
+[tool.setuptools.package-data]
+"cr.templates" = ["*"]
+
 [tool.setuptools.dynamic]
 version = {attr = "cr.VERSION"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ addopts = "--cov cr --cov-report html"
 ignore_missing_imports = true
 
 [tool.setuptools]
-packages = ["cr"]
+packages = ["cr", "cr.templates"]
 
 [tool.setuptools.dynamic]
 version = {attr = "cr.VERSION"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61"]
+requires = ["setuptools>=65.5"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ mypy
 pyinstaller==5.6.*
 pytest
 pytest-cov
-setuptools>=61
+setuptools>=65.5
 twine
 types-paramiko
 wheel

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ build
 coverage
 flake8
 mypy
-pyinstaller==5.4.*
+pyinstaller
 pytest
 pytest-cov
 setuptools>=61

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,6 @@ build
 coverage
 flake8
 mypy
-pip>=22.3
 pyinstaller==5.6.*
 pytest
 pytest-cov

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ build
 coverage
 flake8
 mypy
-pyinstaller
+pyinstaller==5.6.*
 pytest
 pytest-cov
 setuptools>=61

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@ build
 coverage
 flake8
 mypy
+pip>=22.3
 pyinstaller==5.6.*
 pytest
 pytest-cov

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,9 @@
--e ./
 black
 build
 coverage
 flake8
 mypy
+pip>=22.3
 pyinstaller==5.6.*
 pytest
 pytest-cov


### PR DESCRIPTION
Fixes #5 

* Add CodeRed Cloud Django settings templates.
* Check for wsgi.py. If it cannot be found, check if the `django_project` might be set incorrectly and offer to set it.
* Check for Django settings file. If it doesn't exist, offer to create it from a `settings.py`.
* Check and rewrite Django settings file(s) if they seem to be missing references to important environment variables such as `VIRTUAL_HOST` or `DB_HOST`.

Housekeeping:
* Move env to webapp `__init__` instead of args on utility methods.
* Upgrade pyinstaller
* Fix formatting of spec file (also include new templates dir)

Note: PATCH-ing the `custom_django_project` in coderedapi currently redeploys the webapp. In this case, that is undesired behavior as we are trying to fix this pre-deployment. We should probably change coderedapi before releasing this feature.

The code here seems quite inelegant and/or side-effect heavy. I guess that is the nature of what we are trying to do, with a lot of dependent nested logic. But open to suggestions on practical ways to organize it better (`api.py` file is getting a bit massive)