### PR TITLE
Update build chain

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,9 +28,8 @@ $ cr --help
 During development, lint your code with:
 
 ```console
-$ flake8 .
-$ mypy .
-$ black .
+$ ruff format .
+$ ruff check --fix .
 ```
 
 Tests should be written in `tests/test_{name}.py` where name is the source file in `cr/` it is testing.
@@ -105,7 +104,7 @@ Certificate was purchased from: https://SignMyCode.com (issued by Sectigo). Go h
 
 ### Windows
 
-To sign the PyInstaller binaries on Windows, make sure the Windows SDK is installed (i.e. install [Visual Studio Build Tools](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022) then select "Desktop Development with C++"). This is required to get [signtool](https://learn.microsoft.com/en-us/dotnet/framework/tools/signtool-exe)
+To sign the PyInstaller binaries on Windows, make sure the Windows SDK is installed (i.e. install [Visual Studio Build Tools](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022-2024) then select "Desktop Development with C++"). This is required to get [signtool](https://learn.microsoft.com/en-us/dotnet/framework/tools/signtool-exe)
 
 First, convert the certificate + private key into a PFX file (with no password):
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,7 @@ Certificate was purchased from: https://SignMyCode.com (issued by Sectigo). Go h
 
 ### Windows
 
-To sign the PyInstaller binaries on Windows, make sure the Windows SDK is installed (i.e. install [Visual Studio Build Tools](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022-2024) then select "Desktop Development with C++"). This is required to get [signtool](https://learn.microsoft.com/en-us/dotnet/framework/tools/signtool-exe)
+To sign the PyInstaller binaries on Windows, make sure the Windows SDK is installed (i.e. install [Visual Studio Build Tools](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022) then select "Desktop Development with C++"). This is required to get [signtool](https://learn.microsoft.com/en-us/dotnet/framework/tools/signtool-exe)
 
 First, convert the certificate + private key into a PFX file (with no password):
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 CodeRed LLC
+Copyright (c) 2022-2024 CodeRed LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,14 +21,14 @@ stages:
       vmImage: "ubuntu-latest"
     strategy:
       matrix:
-        py38:
-          PYTHON_VERSION: '3.8'
         py39:
           PYTHON_VERSION: '3.9'
         py310:
           PYTHON_VERSION: '3.10'
         py311:
           PYTHON_VERSION: '3.11'
+        py312:
+          PYTHON_VERSION: '3.12'
     steps:
       - task: UsePythonVersion@0
         displayName: "Use Python version"
@@ -67,7 +67,7 @@ stages:
     value: $[startsWith(variables['Build.SourceBranch'], 'refs/tags/v')]
   # Main Python version for building distributables.
   - name: CR_PY_VERSION
-    value: '3.11'
+    value: '3.12'
   # Link the group of Apple passwords from pipeline library.
   - group: 'Apple IDs'
 
@@ -113,9 +113,9 @@ stages:
       artifact: cr.exe
 
   - job: macos11
-    displayName: macOS 11
+    displayName: macOS 12
     pool:
-      vmImage: "macOS-11"
+      vmImage: "macOS-12"
 
     steps:
     - task: UsePythonVersion@0
@@ -126,7 +126,6 @@ stages:
 
     - script: python -m pip install -r requirements-pipeline.txt
       displayName: "CR-QC: Install"
-
     - script: pytest
       displayName: "CR-QC: Test"
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,17 +42,14 @@ stages:
       - script: cr --help
         displayName: "CR-QC: Run CLI"
 
-      - script: flake8 .
-        displayName: "CR-QC: flake8"
+      - script: ruff check .
+        displayName: "CR-QC: ruff check"
+
+      - script: ruff format --check .
+        displayName: "CR-QC: ruff format"
 
       - script: mypy .
         displayName: "CR-QC: mypy"
-
-      - script: black --check .
-        displayName: "CR-QC: black"
-
-      - script: isort --check .
-        displayName: "CR-QC: isort"
 
       - script: pytest
         displayName: "CR-QC: Test"

--- a/cr/api.py
+++ b/cr/api.py
@@ -1,7 +1,7 @@
 """
 Utilities to call CodeRed Cloud API.
 
-Copyright (c) 2022 CodeRed LLC.
+Copyright (c) 2022-2024 CodeRed LLC.
 """
 
 import json

--- a/cr/api.py
+++ b/cr/api.py
@@ -23,15 +23,15 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.progress import Progress
 
+from cr import DOCS_LINK
+from cr import LOGGER
+from cr import USER_AGENT
+from cr import VERSION
 from cr import AppType
 from cr import ConfigurationError
 from cr import DatabaseType
-from cr import DOCS_LINK
 from cr import Env
-from cr import LOGGER
-from cr import USER_AGENT
 from cr import UserCancelError
-from cr import VERSION
 from cr.utils import django_manage_check
 from cr.utils import django_requirements_check
 from cr.utils import django_settings_check

--- a/cr/cli.py
+++ b/cr/cli.py
@@ -38,20 +38,20 @@ from rich.progress import TimeElapsedColumn
 
 from cr import DOCS_LINK
 from cr import LOGGER
-from cr import UserCancelError
 from cr import VERSION
-from cr.api import check_update
+from cr import UserCancelError
 from cr.api import Env
 from cr.api import Webapp
+from cr.api import check_update
 from cr.config import config
 from cr.config import config_path_list
 from cr.config import config_pureposixpath_list
 from cr.config import load_config
 from cr.rich_utils import CONSOLE
 from cr.rich_utils import CONSOLE_ERR
-from cr.rich_utils import osc_reset
 from cr.rich_utils import Progress
 from cr.rich_utils import RichArgparseFormatter
+from cr.rich_utils import osc_reset
 from cr.ssh import Server
 from cr.utils import check_handle
 from cr.utils import git_ignored

--- a/cr/cli.py
+++ b/cr/cli.py
@@ -20,8 +20,9 @@ enabled. Use logging generously to aid in customer support:
 Printing output should be done through the CONSOLE object. Print minimal output
 only as necessary for the user to know the program is working.
 
-Copyright (c) 2022 CodeRed LLC.
+Copyright (c) 2022-2024 CodeRed LLC.
 """
+
 import argparse
 import logging
 import sys

--- a/cr/config.py
+++ b/cr/config.py
@@ -1,8 +1,9 @@
 """
 Loads runtime variables from various config files.
 
-Copyright (c) 2022 CodeRed LLC.
+Copyright (c) 2022-2024 CodeRed LLC.
 """
+
 import configparser
 import os
 from pathlib import Path

--- a/cr/rich_utils.py
+++ b/cr/rich_utils.py
@@ -10,10 +10,10 @@ from typing import Iterable
 from typing import List
 from typing import Optional
 
+from rich.console import WINDOWS
 from rich.console import Console
 from rich.console import Group
 from rich.console import RenderableType
-from rich.console import WINDOWS
 from rich.highlighter import RegexHighlighter
 from rich.measure import measure_renderables
 from rich.padding import Padding

--- a/cr/rich_utils.py
+++ b/cr/rich_utils.py
@@ -1,8 +1,9 @@
 """
 Utilities to format program output with `rich`.
 
-Copyright (c) 2022 CodeRed LLC.
+Copyright (c) 2022-2024 CodeRed LLC.
 """
+
 import argparse
 from typing import Generator
 from typing import Iterable
@@ -160,7 +161,7 @@ class RichArgparseFormatter(
 
         Author: Ali Hamdan (ali.hamdan.dev@gmail.com).
 
-        Copyright (C) 2022.
+        Copyright (C) 2022-2024.
 
         Permission is granted to use, copy, and modify this code in any manner as
         long as this copyright message and disclaimer remain in the source code.
@@ -168,7 +169,7 @@ class RichArgparseFormatter(
 
     Modifications and changes:
 
-        Copyright (c) 2022 CodeRed LLC.
+        Copyright (c) 2022-2024 CodeRed LLC.
     """
 
     @staticmethod

--- a/cr/ssh.py
+++ b/cr/ssh.py
@@ -1,8 +1,9 @@
 """
 Utilities for interacting with CodeRed Cloud host servers.
 
-Copyright (c) 2022 CodeRed LLC.
+Copyright (c) 2022-2024 CodeRed LLC.
 """
+
 import os
 import stat
 from dataclasses import dataclass

--- a/cr/utils.py
+++ b/cr/utils.py
@@ -1,8 +1,9 @@
 """
 Subprocess and filesystem utilities for working with the local project.
 
-Copyright (c) 2022 CodeRed LLC.
+Copyright (c) 2022-2024 CodeRed LLC.
 """
+
 import io
 import os
 import re

--- a/cr/utils.py
+++ b/cr/utils.py
@@ -16,9 +16,9 @@ from typing import Optional
 from typing import Tuple
 from typing import Union
 
+from cr import LOGGER
 from cr import ConfigurationError
 from cr import DatabaseType
-from cr import LOGGER
 
 
 EXCLUDE_DIRNAMES = ["__pycache__", "node_modules", "htmlcov", "venv"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,8 @@ classifiers = [
 ]
 dependencies = [
     "certifi",
-    "paramiko==3.2.*",
-    "rich==13.4.*",
+    "paramiko==3.4.*",
+    "rich==13.7.*",
 ]
 description = "The official CodeRed Cloud command line tool."
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,20 +29,6 @@ cr = "cr.cli:main"
 Homepage = "https://www.codered.cloud/cli/"
 Source = "https://github.com/coderedcorp/cr"
 
-[tool.black]
-line-length = 80
-include = '\.pyi?$'
-exclude = '''
-/(
-    \.eggs
-  | \.git
-  | \.tox
-  | \.venv
-  | _build
-  | build
-)/
-'''
-
 [tool.coverage.run]
 source = ["cr"]
 omit = [
@@ -50,20 +36,22 @@ omit = [
     "venv/*",
 ]
 
-[tool.isort]
-force_alphabetical_sort_within_sections = true
-force_single_line = true
-lines_after_imports = 2
-lines_between_sections = 1
-line_length = 80
-profile = "black"
-skip_gitignore = true
-
 [tool.mypy]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 addopts = "--cov cr --cov-report html"
+
+[tool.ruff]
+line-length = 80
+
+[tool.ruff.lint]
+extend-select = ["I"]
+
+[tool.ruff.lint.isort]
+case-sensitive = false
+force-single-line = true
+lines-after-imports = 2
 
 [tool.setuptools]
 packages = ["cr", "cr.templates"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,9 @@
 -e .
 build
 coverage
-mypy==1.4.*
+mypy==1.11.*
 pip>=22.3
-pyinstaller==5.13.*
+pyinstaller==6.10.*
 pytest
 pytest-cov
 ruff

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,14 +1,12 @@
 -e .
-black==23.*
 build
 coverage
-flake8
-isort
 mypy==1.4.*
 pip>=22.3
 pyinstaller==5.13.*
 pytest
 pytest-cov
+ruff
 setuptools>=65.5
 twine
 types-paramiko


### PR DESCRIPTION
Code:
* Switch from black/flake8/isort to ruff
* Update dependencies

Binaries:
* Bundle with Python 3.12
* Drop support for macOS 11 (deprecated in azure pipelines). Binary requires macOS 12 or newer.

Tested manually with a site hosted on cr-cloud.
