### PR TITLE
Check version control status and common Django errors

### DIFF
--- a/cr/__init__.py
+++ b/cr/__init__.py
@@ -15,6 +15,34 @@ LOGGER = logging.getLogger("cr")
 USER_AGENT = f"CodeRed-CLI/{VERSION} ({DOCS_LINK})"
 
 
+PROD_BRANCHES = [
+    "live",
+    "main",
+    "master",
+    "prod",
+    "production",
+    "release",
+]
+
+
+STAGING_BRANCHES = [
+    "dev",
+    "develop",
+    "development",
+    "gold",
+    "pre-prod",
+    "pre-production",
+    "pre-release",
+    "preprod",
+    "preproduction",
+    "prerelease",
+    "stage",
+    "staging",
+    "test",
+    "testing",
+]
+
+
 class ConfigurationError(Exception):
     """
     Raised when project does not match expected configuration.

--- a/cr/api.py
+++ b/cr/api.py
@@ -250,7 +250,7 @@ class Webapp:
         b = git_branch()
         if b and self.env == Env.STAGING and b not in STAGING_BRANCHES:
             if c and not c.prompt_yn(
-                f"Your are deploying to STAGING from the `{b}` branch!\n"
+                f"You are deploying to STAGING from the `{b}` branch!\n"
                 "It is recommended to deploy from a dedicated staging branch.\n"
                 "Continue anyways?",
                 nouser=True,
@@ -258,7 +258,7 @@ class Webapp:
                 raise UserCancelError()
         if b and self.env == Env.PROD and b not in PROD_BRANCHES:
             if c and not c.prompt_yn(
-                f"Your are deploying to PROD from the `{b}` branch!\n"
+                f"You are deploying to PROD from the `{b}` branch!\n"
                 "It is recommended to deploy from a dedicated production branch.\n"
                 "Continue anyways?",
                 nouser=True,

--- a/cr/cli.py
+++ b/cr/cli.py
@@ -241,12 +241,22 @@ class Deploy(Command):
                 "Re-deploys the website version already on CodeRed Cloud."
             ),
         )
+        p.add_argument(
+            "--skip-predeploy",
+            action="store_true",
+            help=(
+                "Skip common pre-deployment checks. "
+                "Only checks for local configuration errors."
+            ),
+        )
 
     @classmethod
     def run(self, args: argparse.Namespace):
         w = self.get_webapp(args)
         if not args.no_upload:
-            w.local_check_path(args.path, CONSOLE)
+            w.local_check(args.path, CONSOLE)
+            if not args.skip_predeploy:
+                w.local_predeploy(args.path, CONSOLE)
 
         with Progress(
             TextColumn("[progress.description]{task.description}"),
@@ -357,11 +367,21 @@ class Check(Command):
         p.add_argument(*arg_env.args, **arg_env.kwargs)
         p.add_argument(*arg_token.args, **arg_token.kwargs)
         p.add_argument(*arg_path.args, **arg_path.kwargs)
+        p.add_argument(
+            "--skip-predeploy",
+            action="store_true",
+            help=(
+                "Skip common pre-deployment checks. "
+                "Only checks for local configuration errors."
+            ),
+        )
 
     @classmethod
     def run(self, args: argparse.Namespace):
         w = self.get_webapp(args)
-        w.local_check_path(args.path, CONSOLE)
+        w.local_check(args.path, CONSOLE)
+        if not args.skip_predeploy:
+            w.local_predeploy(args.path, CONSOLE)
 
 
 class Logs(Command):
@@ -521,6 +541,14 @@ class Upload(Command):
                 "Defaults to `/www` which is the main directory."
             ),
         )
+        p.add_argument(
+            "--skip-predeploy",
+            action="store_true",
+            help=(
+                "Skip common pre-deployment checks. "
+                "Only checks for local configuration errors."
+            ),
+        )
 
     @classmethod
     def run(self, args: argparse.Namespace):
@@ -529,7 +557,9 @@ class Upload(Command):
         # If the destination is the usual ``/www`` dir, and ``--path`` is a
         # directory, confirm with the user.
         if args.remote == PurePosixPath("/www") and args.path.is_dir():
-            w.local_check_path(args.path, CONSOLE)
+            w.local_check(args.path, CONSOLE)
+            if not args.skip_predeploy:
+                w.local_predeploy(args.path, CONSOLE)
 
         with Progress(
             TextColumn("[progress.description]{task.description}"),

--- a/cr/rich_utils.py
+++ b/cr/rich_utils.py
@@ -11,7 +11,7 @@ from typing import List
 from typing import Optional
 
 from rich.console import WINDOWS
-from rich.console import Console
+from rich.console import Console as _Console
 from rich.console import Group
 from rich.console import RenderableType
 from rich.highlighter import RegexHighlighter
@@ -45,6 +45,8 @@ RICH_THEME = Theme(
         "cr.argparse_text": "default",
         "cr.code": "bright_magenta",
         "cr.progress_print": "bright_black",
+        "cr.success": "bright_green",
+        "cr.fail": "bright_red",
         "cr.update_border": "bright_black",
     }
 )
@@ -62,6 +64,31 @@ class CustomHighlighter(RegexHighlighter):
         # Highlight text in backticks as cr.code
         r"`(?P<code>[^`]*)`",
     ]
+
+
+class Console(_Console):
+    """
+    Adds extra functionality for custom prompt behavior.
+    """
+
+    def prompt_yn(self, message: str, nouser: bool) -> bool:
+        """
+        Prompts the user with Yes/No. If user enters Yes, return True.
+        Otherwise, return False.
+
+        If the prompt occurs within a headless terminal (i.e. in a CI/CD
+        pipeline), always return the value of ``nouser``.
+        """
+        if self.is_interactive:
+            val = self.input(message + " [prompt.choices](y/N)[/] ")
+            return val.strip().lower() == "y"
+        else:
+            self.print(message + " [prompt.choices](yes/no)[/] ")
+            if nouser:
+                self.print("  (Continuing without user input)")
+            else:
+                self.print("  (Not continuting without user input)")
+            return nouser
 
 
 CONSOLE = Console(highlighter=CustomHighlighter(), theme=RICH_THEME)

--- a/cr/utils.py
+++ b/cr/utils.py
@@ -347,7 +347,7 @@ def django_run_check(p: Path) -> Tuple[bool, str]:
 
     Returns a Tuple of success, and program output.
     """
-    code, out, err = exec_proc(["python", (p / "manage.py"), "check"])
+    code, out, err = exec_proc(["python", str(p / "manage.py"), "check"])
     return (code == 0, out + err)
 
 
@@ -358,7 +358,7 @@ def django_run_migratecheck(p: Path) -> Tuple[bool, str]:
     Returns a Tuple of success, and program output.
     """
     code, out, err = exec_proc(
-        ["python", (p / "manage.py"), "makemigrations", "--check"]
+        ["python", str(p / "manage.py"), "makemigrations", "--check"]
     )
     return (code == 0, out + err)
 


### PR DESCRIPTION
To help eliminate common foot-guns, and improve the developer experience, we are adding a set of new checks to help prevent accidental deployment errors.

On the `check`, `deploy`, and `upload` commands, run a set of new "predeploy" checks which includes:
* Check if the git branch matches the deployment environment (staging/prod).
* Check if there are un-committed or un-pushed changes.
* Run `manage.py check`
* Run `manage.py makemigrations --check`.

These can be disabled by using the `--skip-predeploy` argument.

Additionally, in non-interactive environments (i.e. CI/CD pipelines), `cr` will automatically continue or cancel based on the severity of the check that has failed.

Fixes #12 