### PR TITLE
Do not use ssh-agent when connecting to server

### DIFF
--- a/cr/ssh.py
+++ b/cr/ssh.py
@@ -58,6 +58,7 @@ class Server:
             port=22,
             username=self.user,
             password=self.passwd,
+            allow_agent=False,
             look_for_keys=False,
         )
         self._client = c


### PR DESCRIPTION
Fix for 'Fatal: could not get keys from ssh-agent'

Fixes #22 