### PR TITLE
UX improvements to SFTP, SSH, logs

### DIFF
--- a/cr/api.py
+++ b/cr/api.py
@@ -511,9 +511,13 @@ class Webapp:
         """
         kill = False
         since = 0
+        # Poll for up to 180 seconds (18 * 10 sec sleep).
         for i in range(18):
             data = self.api_get_logs(since=since)
             logs = data["logs"]
+            # If there are more than 100 lines, skip the fancy scrolling
+            # and just print the whole thing.
+            biglogs = len(logs) > 100
             if not logs:
                 kill = True
             for line in logs:
@@ -530,7 +534,8 @@ class Webapp:
                 )
                 if "\x04" in text:
                     kill = True
-                time.sleep(0.05)
+                if not biglogs:
+                    time.sleep(0.05)
             if kill:
                 break
             time.sleep(10)

--- a/cr/cli.py
+++ b/cr/cli.py
@@ -651,22 +651,6 @@ class Sftp(Command):
         port = 22
         user = w.handle
         passwd = ""
-        with Progress(
-            TextColumn("[progress.description]{task.description}"),
-            SpinnerColumn(),
-            console=CONSOLE,
-            transient=True,
-        ) as pbar:
-            # Generate a new SFTP password from CodeRed Cloud API.
-            t = pbar.add_task("Resetting system password", total=None)
-            passwd = w.api_get_sftp_password()
-            pbar.update(t, total=1, completed=1)
-        CONSOLE.print(
-            f"SFTP host:       {host}\n"
-            f"SFTP port:       {port}\n"
-            f"SFTP user:       {user}\n"
-            f"System password: {passwd}"
-        )
         p = Panel(
             "[logging.level.warning]NOTE:[/] "
             "Passwords are temporary and may be reset every time your "
@@ -675,6 +659,22 @@ class Sftp(Command):
             border_style="cr.update_border",
         )
         CONSOLE_ERR.print(p)
+        CONSOLE.print(
+            f"SFTP host:       {host}\n"
+            f"SFTP port:       {port}\n"
+            f"SFTP user:       {user}"
+        )
+        with Progress(
+            TextColumn("[progress.description]{task.description}"),
+            SpinnerColumn(),
+            console=CONSOLE,
+            transient=True,
+        ) as pbar:
+            # Generate a new SFTP password from CodeRed Cloud API.
+            t = pbar.add_task("System password:", total=None)
+            passwd = w.api_get_sftp_password()
+            pbar.update(t, total=1, completed=1)
+        CONSOLE.print(f"System password: {passwd}")
 
 
 class Ssh(Command):
@@ -710,20 +710,6 @@ class Ssh(Command):
         port = 2222
         user = w.handle
         passwd = ""
-        with Progress(
-            TextColumn("[progress.description]{task.description}"),
-            SpinnerColumn(),
-            console=CONSOLE,
-            transient=True,
-        ) as pbar:
-            # Generate a new SFTP password from CodeRed Cloud API.
-            t = pbar.add_task("Resetting system password", total=None)
-            passwd = w.api_get_sftp_password()
-            pbar.update(t, total=1, completed=1)
-        CONSOLE.print(
-            f"SSH command:     ssh -p {port} {user}@{host}\n"
-            f"System password: {passwd}"
-        )
         p = Panel(
             "[logging.level.warning]NOTE:[/] "
             "Passwords are temporary and may be reset every time your "
@@ -732,6 +718,18 @@ class Ssh(Command):
             border_style="cr.update_border",
         )
         CONSOLE_ERR.print(p)
+        CONSOLE.print(f"SSH command:     ssh -p {port} {user}@{host}")
+        with Progress(
+            TextColumn("[progress.description]{task.description}"),
+            SpinnerColumn(),
+            console=CONSOLE,
+            transient=True,
+        ) as pbar:
+            # Generate a new SFTP password from CodeRed Cloud API.
+            t = pbar.add_task("System password:", total=None)
+            passwd = w.api_get_sftp_password()
+            pbar.update(t, total=1, completed=1)
+        CONSOLE.print(f"System password: {passwd}")
 
 
 class Upload(Command):


### PR DESCRIPTION
* Show password resetting inline, to reduce keep output more consistent.
* Move warning above the SFTP/SSH info, to keep output more consistent.
* Do not scroll log output greater than 100 lines long.